### PR TITLE
Prevent QuotaExceededError when storage is full

### DIFF
--- a/jquery.memoized.ajax.js
+++ b/jquery.memoized.ajax.js
@@ -60,7 +60,12 @@
       return item && JSON.parse(item);
     // set
     } else {
-      storage.setItem(key, JSON.stringify(value));
+      try {
+        storage.setItem(key, JSON.stringify(value));
+      } catch (err) {
+        // prevent catching old values
+        storage.removeItem(key);
+      }
     }
   }
 


### PR DESCRIPTION
I faced this issue when using a large data in localStorage, so my solution is when a exception is thrown the key should be erased  to prevent outdated data.

I hope this helps anyone that faces the same problem.
